### PR TITLE
feat: inherit transition from selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,27 +60,34 @@ import { transition } from 'd3-transition';
 const quickTransition = transition()
   .duration(300);
 
-const join = dataJoin('li', 'animal')
+const join = dataJoin('li', 'animal');
+
+const container = select('ul')
   .transition(quickTransition);
 
-join(select('ul'), ['Aardvark', 'Beaver', 'Cat'])
+join(container, ['Aardvark', 'Beaver', 'Cat'])
   .text(d => d);
 ```
 
-To disable the default transition (only required if `d3-transition` is available), explicitly set a transition with a zero duration -
+To disable transitions, explicitly retrieve the selection from the transition -
 
 ```js
 import { dataJoin } from 'd3fc-data-join';
 import { select } from 'd3-selection';
 import { transition } from 'd3-transition';
 
-const zeroDurationTransition = transition()
-  .duration(0);
+const quickTransition = transition()
+  .duration(300);
 
-const join = dataJoin('li', 'animal')
-  .transition(zeroDurationTransition);
+const join = dataJoin('li', 'animal');
 
-join(select('ul'), ['Aardvark', 'Beaver', 'Cat'])
+const root = select('body')
+  .transition(quickTransition);
+
+const container = root.select('ul')
+  .selection();
+
+join(container, ['Aardvark', 'Beaver', 'Cat'])
   .text(d => d);
 ```
 
@@ -99,7 +106,3 @@ Set the class name used to select elements and applied to inserted elements. Def
 <a name="dataJoin_key" href="#dataJoin_key">#</a> *dataJoin*.**key**(*keyFunc*)
 
 Specifies the key function used by the data-join. Defaults to index-based. Equivalent to specifying a `key` argument when calling [`selection.data()`](https://github.com/d3/d3-selection#selection_data).
-
-<a name="dataJoin_transition" href="#dataJoin_transition">#</a> *dataJoin*.**transition**(*transition*)
-
-Specifies the transition to be used if `d3-transition` is available. Defaults to `null` which uses the default transition,`. Equivalent to specifying a `key` argument when calling `[selection.data()](https://github.com/d3/d3-selection#selection_data)`.

--- a/src/dataJoin.js
+++ b/src/dataJoin.js
@@ -18,10 +18,14 @@ export default (element, className) => {
     element = element || 'g';
 
     let key = (_, i) => i;
-    let transition = null;
 
     const dataJoin = function(container, data) {
         data = data || ((d) => d);
+
+        const transition = container.selection ? container : null;
+        if (transition) {
+            container = container.selection();
+        }
 
         const selected = container.selectAll((d, i, nodes) =>
               Array.from(nodes[i].childNodes)
@@ -40,9 +44,8 @@ export default (element, className) => {
         update = update.merge(enter);
 
         // if transitions are enabled apply a default fade in/out transition
-        const transitionsAvailable = selection.prototype.transition != null;
-        const trasitionHasNonZeroDuration = transition == null || transition.duration() > 0;
-        if (transitionsAvailable && trasitionHasNonZeroDuration) {
+        if (transition) {
+            update = update.transition(transition);
             enter.style('opacity', effectivelyZero)
                 .transition(transition)
                 .style('opacity', 1);
@@ -78,13 +81,6 @@ export default (element, className) => {
             return key;
         }
         key = args[0];
-        return dataJoin;
-    };
-    dataJoin.transition = (...args) => {
-        if (!args.length) {
-            return transition;
-        }
-        transition = args[0];
         return dataJoin;
     };
 

--- a/test/dataJoinSpec.js
+++ b/test/dataJoinSpec.js
@@ -115,17 +115,16 @@ describe('dataJoin', () => {
 
     describe('when d3-transition included and a custom transition is specified', () => {
         const timeout = 20;
-        let customTransition;
+        let join;
 
         beforeEach(() => {
             selection.prototype.transition = selectionTransition;
-            customTransition = container.transition()
+            join = dataJoin();
+            container = container.transition()
                 .duration(1);
         });
 
         it('should apply a fade in transition', (done) => {
-            const join = dataJoin()
-                .transition(customTransition);
             const update = join(container, data);
             const node = update.enter().node();
 
@@ -139,10 +138,22 @@ describe('dataJoin', () => {
             }, timeout);
         });
 
+        it('should apply transitions to the update selection', (done) => {
+            const update = join(container, [1]);
+            const node = update.node();
+
+            update.style('opacity', (d) => d);
+            expect(node.style.opacity).toBeCloseTo(0.000001, 6);
+
+            setTimeout(() => {
+                expect(node.style.opacity).toBe('1');
+                done();
+            }, timeout);
+        });
+
         it('should apply a fade out transition', (done) => {
-            const join = dataJoin()
-                .transition(customTransition);
-            container.append('g')
+            container.selection()
+                .append('g')
                 .style('opacity', '1');
             const update = join(container, []);
             const node = update.exit().node();
@@ -158,9 +169,8 @@ describe('dataJoin', () => {
         });
 
         it('should return the untransitioned exit selection', () => {
-            const join = dataJoin()
-                .transition(customTransition);
-            container.append('g')
+            container.selection()
+                .append('g')
                 .style('opacity', '1');
             const update = join(container, []);
 
@@ -173,9 +183,8 @@ describe('dataJoin', () => {
         });
 
         it('should allow the transition to be disabled', () => {
-            customTransition.duration(0);
-            const join = dataJoin()
-                .transition(customTransition);
+            container = container.selection();
+
             const update = join(container, data);
             const node = update.enter().node();
 


### PR DESCRIPTION
BREAKING CHANGE: `.transition()` has been removed. Transitions should now be passed in place of the container selection.