### PR TITLE
fix: expose the exit transition (rather than the selection)

### DIFF
--- a/src/dataJoin.js
+++ b/src/dataJoin.js
@@ -39,7 +39,7 @@ export default (element, className) => {
             .append(element)
             .attr('class', className);
 
-        const exit = update.exit();
+        let exit = update.exit();
 
         // automatically merge in the enter selection
         update = update.merge(enter);
@@ -51,7 +51,7 @@ export default (element, className) => {
             enter.style('opacity', effectivelyZero)
                 .transition(transition)
                 .style('opacity', 1);
-            exit.transition(transition)
+            exit = exit.transition(transition)
                 .style('opacity', effectivelyZero)
                 .remove();
         } else {


### PR DESCRIPTION
the selection.transition() function returns a new transition. Therefore, in order to allow people to customise the exit transitions, this is what the d3fc-data-join exit function should expose.

This isn't required for the enter selection, due to the use of selection.merge